### PR TITLE
Implement resiliency and security recommendations for SDKs

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -1,0 +1,66 @@
+# Token Metrics AI API – Production Readiness Audit
+
+## Executive Summary
+- **Overall maturity**: The SDKs provide convenient wrappers around the Token Metrics REST API, but critical production-readiness gaps remain in reliability, observability, dependency footprint, security hygiene, and automated quality gates. These issues would be amplified at 1M+ MAU scale.
+- **Highest-risk findings**: Missing HTTP timeouts/retries and silent exception handling in the Python client, noisy console/progress logging baked into both SDKs, a hard-coded API key in the JavaScript test harness, and oversized dependency sets that complicate supply-chain governance.
+- **Key opportunities**: Adopt resilient HTTP layers (timeouts, retries, circuit breaking), invest in typed response models and validation, harden dependency management, enforce secure secrets handling, and expand automated testing (unit + contract + load) with CI integration.
+
+## Python SDK Findings
+### Reliability & Performance
+- `_request` issues requests without timeouts or connection pooling, increasing the risk of hung threads under network turbulence. Introduce a shared `requests.Session` with configurable timeouts and retry/backoff policies (e.g., `urllib3.Retry`).【F:python/tmai_api/base.py†L18-L47】
+- `_paginated_request` silently swallows every exception, which obscures API outages, creates data gaps, and complicates incident response. Emit structured errors and aggregate partial successes instead of `pass`ing on failures.【F:python/tmai_api/base.py†L174-L221】
+- Paginated fetches always reset `page=0` and ignore server pagination, making the client incompatible with legitimate paged APIs. Extend to iterate across `page` until exhaustion while respecting server rate limits.【F:python/tmai_api/base.py†L168-L199】
+- Bundling `tqdm` progress bars inside a library pollutes stdout in server contexts and can deadlock multiprocessing when stdout pipes are saturated. Replace with pluggable logging hooks or remove by default.【F:python/tmai_api/base.py†L154-L205】
+
+### API Design & Maintainability
+- Responses are returned as raw dicts/lists without schema validation; downstream code must defensively parse dynamic shapes. Define Pydantic/TypedDict models and conversion helpers for predictable contracts.【F:python/tmai_api/base.py†L174-L221】
+- `to_dataframe` requires `pandas` at runtime even for non-DataFrame workflows; consider lazy imports or optional extras to avoid imposing heavy transitive dependencies on minimal installs.【F:python/tmai_api/base.py†L223-L243】
+- Endpoint methods expose dozens of loosely typed kwargs (e.g., `TokensEndpoint.get`), making misuse easy. Adopt dataclass/TypedDict parameter objects or method overloads for clarity.【F:python/tmai_api/endpoints/tokens.py†L6-L40】
+
+### Security & Compliance
+- API keys are passed via custom `api_key` headers; confirm TLS pinning / standard `Authorization` bearer flows for easier audit. At minimum, support environment variable loading plus secrets managers to avoid hard-coded keys.【F:python/tmai_api/base.py†L30-L40】
+
+### Packaging & Dependencies
+- `setup.cfg` pulls in `matplotlib` and `vectorbt`, which are large, optional visualization/backtesting stacks that balloon cold-start time and attack surface. Split into extras (`pip install tmai-api[analysis]`).【F:python/setup.cfg†L18-L24】
+- Distribute wheels free of build artefacts (`python/build/`) to reduce install size and prevent stale code divergence; ensure `.gitignore` excludes build outputs.
+
+### Testing & Tooling
+- Running `pytest` fails because `requests` is not installed in the test environment, revealing missing dev dependency documentation. Provide a `requirements-dev.txt` and/or Poetry/UV config for deterministic environments.【b09c2a†L1-L22】
+- Unit coverage is shallow (only instantiation and mocked token calls). Add contract tests that mock pagination, error paths, and response parsing; integrate with CI and add load/regression tests.
+
+## JavaScript SDK Findings
+### Reliability & Performance
+- `_request` lacks configurable timeouts and retry logic; use Axios interceptors or libraries like `axios-retry` and expose knobs for rate limiting/backoff.【F:js/src/base.js†L27-L55】
+- `_paginatedRequest` logs directly to `console` and swallows chunk errors, which breaks serverless/cloud logging baselines. Replace with dependency-injected logger and surface partial-failure metadata.【F:js/src/base.js†L171-L228】
+- Pagination ignores API-provided cursors/pages similar to Python client; expand to iterate fully and respect per-endpoint throttles.【F:js/src/base.js†L125-L209】
+
+### Security
+- `js/test/test.js` embeds a live-looking API key in source control; remove immediately and rotate affected credentials. Replace with environment variables or mocked fixtures.【F:js/test/test.js†L17-L135】
+
+### Packaging & Dependencies
+- `package.json` lists server-specific dependencies (`express`, `cors`, `dotenv`) that are unnecessary for an SDK and inflate bundle/runtime size. Refactor into dev dependencies or dedicated example app packages.【F:js/package.json†L1-L34】
+- Publish transpiled, tree-shakeable bundles (ESM + CJS) with TypeScript type declarations to improve DX and compatibility with bundlers.
+
+### Testing & Tooling
+- Jest script exists but there are no automated unit tests; the current `test.js` executes live API calls and will fail in CI. Replace with mocked Jest suites, add linting (`eslint`, `prettier`), and integrate GitHub Actions for regression coverage.【F:js/package.json†L9-L13】【F:js/test/test.js†L1-L208】
+
+## Cross-Cutting Recommendations
+1. **Resilience & Scalability**
+   - Build shared HTTP client infrastructure (timeouts, retries, circuit breaking, rate limiting) and instrument metrics/tracing hooks for observability.
+   - Support asynchronous/batched operations (e.g., `asyncio`, worker pools) to handle 1M+ user workloads with minimal blocking.
+2. **Security & Compliance**
+   - Eliminate hard-coded secrets, add secret scanning to CI, and enforce API key rotation policies.
+   - Provide official threat modeling / SOC2-ready logging of request metadata while masking sensitive payloads.
+3. **Dependency & Release Management**
+   - Adopt lockfiles (`requirements.lock`, `package-lock.json`/`pnpm-lock.yaml`) and automated dependency scanning (Dependabot, npm audit).
+   - Version SDKs with semantic releases; add changelog automation and backward compatibility guarantees.
+4. **Observability & DX**
+   - Add structured logging (JSON) with log levels, integrate with OpenTelemetry for distributed tracing, and expose hooks for users to plug in custom loggers.
+   - Expand documentation to include rate limits, pagination semantics, and migration guides; link to SLA/uptime docs from README.【F:README.md†L1-L134】
+5. **Quality Gates**
+   - Establish CI pipelines covering lint, type-check, unit/integration tests, packaging smoke tests, and security scans (Bandit, npm audit). Enforce code owners + reviews for sensitive areas.
+
+## Next Steps
+- Prioritize remediation of high-risk findings (HTTP resilience, secret hygiene, dependency pruning) in the next sprint.
+- Define an engineering roadmap for medium-term improvements (typed models, async clients, observability, CI/CD hardening).
+- Schedule quarterly security reviews and performance load tests to validate readiness for 1M+ users.

--- a/js/package.json
+++ b/js/package.json
@@ -22,10 +22,7 @@
   "author": "Token Metrics",
   "license": "MIT",
   "dependencies": {
-    "axios": "^1.8.4",
-    "cors": "^2.8.5",
-    "dotenv": "^16.4.7",
-    "express": "^5.1.0"
+    "axios": "^1.7.7"
   },
   "devDependencies": {
     "jest": "^29.7.0",

--- a/js/src/base.js
+++ b/js/src/base.js
@@ -1,4 +1,4 @@
-const axios = require('axios');
+const { ApiRequestError } = require('./errors');
 
 /**
  * Base class for all API endpoints
@@ -11,7 +11,7 @@ class BaseEndpoint {
    */
   constructor(client) {
     this.client = client;
-    this.baseUrl = client.constructor.BASE_URL;
+    this.baseUrl = client.baseUrl;
   }
 
   /**
@@ -25,33 +25,34 @@ class BaseEndpoint {
    * @private
    */
   async _request(method, endpoint, params = null, json = null) {
-    const url = `${this.baseUrl}/${endpoint}`;
-    const headers = {
-      'accept': 'application/json',
-      'api_key': this.client.apiKey
-    };
+    const normalizedMethod = method.toUpperCase();
+    if (!['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS', 'HEAD'].includes(normalizedMethod)) {
+      throw new Error(`Unsupported HTTP method: ${method}`);
+    }
+
+    const headers = this.client.buildHeaders();
+    if (['POST', 'PUT', 'PATCH'].includes(normalizedMethod)) {
+      headers['content-type'] = 'application/json';
+    }
 
     try {
-      let response;
-
-      if (method.toLowerCase() === 'get') {
-        response = await axios.get(url, { headers, params });
-      } else if (method.toLowerCase() === 'post') {
-        headers['content-type'] = 'application/json';
-        response = await axios.post(url, json, { headers });
-      } else {
-        throw new Error(`Unsupported HTTP method: ${method}`);
-      }
-
+      const response = await this.client.http.request({
+        method: normalizedMethod,
+        url: endpoint.startsWith('/') ? endpoint : `/${endpoint}`,
+        headers,
+        params: params || undefined,
+        data: json || undefined
+      });
       return response.data;
     } catch (error) {
-      if (error.response) {
-        throw new Error(`API Error: ${error.response.status} - ${error.response.data.message || error.response.statusText}`);
-      } else if (error.request) {
-        throw new Error('No response received from API');
-      } else {
-        throw error;
-      }
+      const status = error.response ? error.response.status : undefined;
+      throw new ApiRequestError({
+        endpoint,
+        method: normalizedMethod,
+        params,
+        status,
+        originalError: error
+      });
     }
   }
 
@@ -149,16 +150,19 @@ class BaseEndpoint {
       'default': 1000
     };
 
-    const startDate = params.startDate;
-    const endDate = params.endDate;
+    const workingParams = { ...(params || {}) };
 
-    const limit = customLimit !== null ? customLimit : 
+    const startDate = workingParams.startDate;
+    const endDate = workingParams.endDate;
+
+    const limit = customLimit !== null ? customLimit :
       (endpointLimits[endpoint] || endpointLimits.default);
 
-    params.limit = limit;
+    workingParams.limit = limit;
 
-    if (params.page !== undefined) {
-      delete params.page;
+    const pageSeed = workingParams.page ?? 0;
+    if (workingParams.page !== undefined) {
+      delete workingParams.page;
     }
 
     const dateChunks = !startDate || !endDate ? 
@@ -167,11 +171,10 @@ class BaseEndpoint {
 
     const allData = [];
     const combinedMeta = {};
-
-    console.log(`Fetching ${endpoint} data...`);
+    const errors = [];
 
     for (const [chunkStart, chunkEnd] of dateChunks) {
-      const chunkParams = { ...params };
+      const chunkParams = { ...workingParams };
       if (chunkStart) {
         chunkParams.startDate = chunkStart;
       }
@@ -181,51 +184,138 @@ class BaseEndpoint {
 
       chunkParams.limit = limit;
 
-      chunkParams.page = 0;
+      let nextPage = pageSeed;
 
-      try {
-        const response = await this._request(method, endpoint, chunkParams, null);
+      while (true) {
+        chunkParams.page = nextPage;
 
-        if (response && typeof response === 'object') {
-          if (response.data) {
-            if (Array.isArray(response.data)) {
-              allData.push(...response.data);
-            } else {
-              allData.push(response.data);
-            }
+        try {
+          const response = await this._request(method, endpoint, chunkParams, null);
+          const { dataItems, metadata } = this._extractData(response);
+
+          if (dataItems.length) {
+            allData.push(...dataItems);
           }
 
-          Object.entries(response).forEach(([key, value]) => {
-            if (key !== 'data') {
-              combinedMeta[key] = value;
-            }
-          });
-        } else if (Array.isArray(response)) {
-          allData.push(...response);
-        } else if (response) {
-          allData.push(response);
-        }
-      } catch (error) {
-        console.error(`Error fetching chunk ${chunkStart} to ${chunkEnd}: ${error.message}`);
-      }
+          Object.assign(combinedMeta, metadata);
 
-      console.log(`Processed chunk: ${chunkStart || 'start'} to ${chunkEnd || 'end'}`);
+          if (typeof this.client.progressCallback === 'function') {
+            this.client.progressCallback({
+              endpoint,
+              chunk: { startDate: chunkStart, endDate: chunkEnd },
+              page: nextPage,
+              itemsFetched: dataItems.length
+            });
+          }
+
+          nextPage = this._calculateNextPage(metadata, nextPage, dataItems.length, limit);
+          if (nextPage === null || nextPage === undefined) {
+            break;
+          }
+        } catch (error) {
+          if (this.client.allowPartialResults) {
+            errors.push({
+              chunk: { startDate: chunkStart, endDate: chunkEnd, page: nextPage },
+              error: error.message
+            });
+            break;
+          }
+
+          throw error;
+        }
+      }
     }
 
     if (allData.length === 0) {
       return { data: [] };
     }
 
+    let result;
     if (Object.keys(combinedMeta).length > 0) {
-      return {
+      result = {
         ...combinedMeta,
         data: allData
       };
     } else if (allData.length > 0 && typeof allData[0] === 'object') {
-      return { data: allData };
+      result = { data: allData };
     } else {
-      return allData;
+      result = allData;
     }
+
+    if (errors.length) {
+      if (result && typeof result === 'object' && !Array.isArray(result)) {
+        return { ...result, errors };
+      }
+
+      return { data: result, errors };
+    }
+
+    return result;
+  }
+
+  _extractData(response) {
+    if (response && typeof response === 'object' && !Array.isArray(response)) {
+      const { data, ...metadata } = response;
+      if (Array.isArray(data)) {
+        return { dataItems: data, metadata };
+      }
+      if (data === null || data === undefined) {
+        return { dataItems: [], metadata };
+      }
+      return { dataItems: [data], metadata };
+    }
+
+    if (Array.isArray(response)) {
+      return { dataItems: response, metadata: {} };
+    }
+
+    if (response === null || response === undefined) {
+      return { dataItems: [], metadata: {} };
+    }
+
+    return { dataItems: [response], metadata: {} };
+  }
+
+  _calculateNextPage(metadata, previousPage, received, pageSize) {
+    const directKeys = ['next_page', 'nextPage', 'next_page_token', 'nextPageToken'];
+    for (const key of directKeys) {
+      if (metadata[key]) {
+        return metadata[key];
+      }
+    }
+
+    const totalPages = metadata.total_pages ?? metadata.totalPages;
+    const currentPage = metadata.page ?? metadata.current_page ?? metadata.currentPage;
+
+    if (totalPages !== undefined && currentPage !== undefined) {
+      const total = Number(totalPages);
+      const current = Number(currentPage);
+      if (!Number.isNaN(total) && !Number.isNaN(current) && current + 1 < total) {
+        return current + 1;
+      }
+      return null;
+    }
+
+    const hasMore = metadata.has_more ?? metadata.hasMore;
+    if (hasMore === false) {
+      return null;
+    }
+    if (hasMore === true) {
+      const previousNumeric = Number(previousPage);
+      const base = Number.isNaN(previousNumeric) ? 0 : previousNumeric;
+      return base + 1;
+    }
+
+    if (received < pageSize || pageSize === 0) {
+      return null;
+    }
+
+    const previousNumeric = Number(previousPage);
+    if (Number.isNaN(previousNumeric)) {
+      return null;
+    }
+
+    return previousNumeric + 1;
   }
 }
 

--- a/js/src/client.js
+++ b/js/src/client.js
@@ -1,3 +1,7 @@
+const axios = require('axios');
+
+const { MissingApiKeyError } = require('./errors');
+
 /**
  * Main client for interacting with the Token Metrics AI API.
  */
@@ -9,12 +13,35 @@ class TokenMetricsClient {
 
   /**
    * Initialize the Token Metrics client.
-   * 
+   *
    * @param {string} apiKey - Your Token Metrics API key
+   * @param {Object} options - Optional configuration overrides
    */
-  constructor(apiKey) {
-    this.apiKey = apiKey;
-    
+  constructor(apiKey, options = {}) {
+    const resolvedKey = apiKey || process.env.TMAI_API_KEY || process.env.TM_API_KEY;
+    if (!resolvedKey) {
+      throw new MissingApiKeyError();
+    }
+
+    const {
+      baseUrl = TokenMetricsClient.BASE_URL,
+      timeout = 10000,
+      retries = 3,
+      retryDelay = 300,
+      retryStatusCodes = [429, 500, 502, 503, 504],
+      httpClient,
+      allowPartialResults = false,
+      progressCallback = null
+    } = options;
+
+    this.apiKey = resolvedKey;
+    this.baseUrl = baseUrl.replace(/\/?$/, '');
+    this.timeout = timeout;
+    this.allowPartialResults = allowPartialResults;
+    this.progressCallback = progressCallback;
+
+    this.http = httpClient || this._createHttpClient({ timeout, retries, retryDelay, retryStatusCodes });
+
     const TokensEndpoint = require('./endpoints/tokens');
     const AIAgentEndpoint = require('./endpoints/ai_agent');
     const TradingSignalsEndpoint = require('./endpoints/trading_signals');
@@ -25,7 +52,7 @@ class TokenMetricsClient {
     const TraderIndicesEndpoint = require('./endpoints/trader_indices');
     const MarketMetricsEndpoint = require('./endpoints/market_metrics');
     const AIReportsEndpoint = require('./endpoints/ai_reports');
-    
+
     const InvestorIndicesEndpoint = require('./endpoints/investor_indices');
     const CryptoInvestorsEndpoint = require('./endpoints/crypto_investors');
     const TopMarketCapTokensEndpoint = require('./endpoints/top_market_cap_tokens');
@@ -41,7 +68,7 @@ class TokenMetricsClient {
     const SectorIndicesPerformanceEndpoint = require('./endpoints/sector_indices_performance');
     const IndexTransactionEndpoint = require('./endpoints/index_transaction');
     const SectorIndexTransactionEndpoint = require('./endpoints/sector_index_transaction');
-    
+
     this.tokens = new TokensEndpoint(this);
     this.aiAgent = new AIAgentEndpoint(this);
     this.tradingSignals = new TradingSignalsEndpoint(this);
@@ -52,7 +79,7 @@ class TokenMetricsClient {
     this.traderIndices = new TraderIndicesEndpoint(this);
     this.marketMetrics = new MarketMetricsEndpoint(this);
     this.aiReports = new AIReportsEndpoint(this);
-    
+
     this.investorIndices = new InvestorIndicesEndpoint(this);
     this.cryptoInvestors = new CryptoInvestorsEndpoint(this);
     this.topMarketCapTokens = new TopMarketCapTokensEndpoint(this);
@@ -68,6 +95,41 @@ class TokenMetricsClient {
     this.sectorIndicesPerformance = new SectorIndicesPerformanceEndpoint(this);
     this.indexTransaction = new IndexTransactionEndpoint(this);
     this.sectorIndexTransaction = new SectorIndexTransactionEndpoint(this);
+  }
+
+  _createHttpClient({ timeout, retries, retryDelay, retryStatusCodes }) {
+    const instance = axios.create({
+      baseURL: this.baseUrl,
+      timeout
+    });
+
+    instance.interceptors.response.use(
+      (response) => response,
+      async (error) => {
+        const config = error.config || {};
+        const status = error.response ? error.response.status : null;
+
+        config.__retryCount = config.__retryCount || 0;
+
+        if (config.__retryCount >= retries || !status || !retryStatusCodes.includes(status)) {
+          return Promise.reject(error);
+        }
+
+        config.__retryCount += 1;
+        const delay = Math.pow(2, config.__retryCount - 1) * retryDelay;
+        await new Promise((resolve) => setTimeout(resolve, delay));
+        return instance.request(config);
+      }
+    );
+
+    return instance;
+  }
+
+  buildHeaders() {
+    return {
+      accept: 'application/json',
+      api_key: this.apiKey
+    };
   }
 }
 

--- a/js/src/errors.js
+++ b/js/src/errors.js
@@ -1,0 +1,24 @@
+class MissingApiKeyError extends Error {
+  constructor() {
+    super('An API key is required. Provide it explicitly or set the TMAI_API_KEY environment variable.');
+    this.name = 'MissingApiKeyError';
+  }
+}
+
+class ApiRequestError extends Error {
+  constructor({ endpoint, method, params, status, originalError }) {
+    const statusLabel = status ? ` status=${status}` : '';
+    super(`API request failed:${statusLabel} method=${method} endpoint=${endpoint}`);
+    this.name = 'ApiRequestError';
+    this.endpoint = endpoint;
+    this.method = method;
+    this.params = params;
+    this.status = status;
+    this.originalError = originalError;
+  }
+}
+
+module.exports = {
+  MissingApiKeyError,
+  ApiRequestError
+};

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -1,7 +1,9 @@
 const TokenMetricsClient = require('./client');
 const BaseEndpoint = require('./base');
+const errors = require('./errors');
 
 module.exports = {
   TokenMetricsClient,
-  BaseEndpoint
+  BaseEndpoint,
+  ...errors
 };

--- a/js/test/test.js
+++ b/js/test/test.js
@@ -14,7 +14,7 @@
 const { TokenMetricsClient } = require('../src/index');
 const assert = require('assert');
 
-const apiKey = "tm-a123f8d9-2cde-4e50-af3b-c5e2b7ffcc81";
+const apiKey = process.argv[2] || process.env.TMAI_API_KEY || process.env.TM_API_KEY;
 
 if (!apiKey) {
   console.error('Please provide your Token Metrics API key as a command line argument or set the TM_API_KEY environment variable');

--- a/python/.gitignore
+++ b/python/.gitignore
@@ -1,5 +1,6 @@
 # Add to .gitignore
 dist/
+build/
 *.egg-info/
 __pycache__/
 *.py[cod]

--- a/python/README.md
+++ b/python/README.md
@@ -21,6 +21,12 @@ The official Python SDK for Token Metrics AI API - providing professional invest
 
 ```bash
 pip install tmai-api
+
+# Include optional DataFrame helpers
+pip install "tmai-api[dataframe]"
+
+# Install analysis extras (plots, backtesting)
+pip install "tmai-api[analysis]"
 ```
 
 ## Quick Start
@@ -28,7 +34,7 @@ pip install tmai-api
 ```python
 from tmai_api import TokenMetricsClient
 
-# Initialize the client with your API key
+# Initialize the client with your API key or environment variable
 client = TokenMetricsClient(api_key="your-api-key")
 
 # Get information for top cryptocurrencies
@@ -142,9 +148,13 @@ plt.show()
 
 All API requests require an API key. You can get your API key by signing up at [Token Metrics](https://tokenmetrics.com).
 
+```bash
+export TMAI_API_KEY="your-api-key"
+```
+
 ```python
-# Initialize with your API key
-client = TokenMetricsClient(api_key="your-api-key")
+# The client will automatically read the key from the TMAI_API_KEY environment variable
+client = TokenMetricsClient()
 ```
 
 ## Error Handling
@@ -152,18 +162,20 @@ client = TokenMetricsClient(api_key="your-api-key")
 The SDK provides built-in error handling for API requests:
 
 ```python
+from tmai_api.exceptions import APIRequestError
+
 try:
     data = client.tokens.get(symbol="INVALID_SYMBOL")
-except Exception as e:
-    print(f"Error: {e}")
-    # Handle the error appropriately
+except APIRequestError as exc:
+    print(f"Request failed: {exc}")
+    # Handle the error appropriately or retry
 ```
 
 ## Requirements
 
-- Python 3.6+
-- `requests` package
-- `pandas` package
+- Python 3.8+
+- `requests`
+- Optional: `pandas` (for DataFrame helpers), `matplotlib` / `vectorbt` for analysis extras
 
 ## Documentation
 
@@ -174,6 +186,13 @@ For complete API documentation, visit:
 ## Contributing
 
 Contributions are welcome! Please feel free to submit a Pull Request.
+
+### Development Setup
+
+```bash
+pip install -r requirements-dev.txt
+pytest
+```
 
 ## License
 

--- a/python/requirements-dev.txt
+++ b/python/requirements-dev.txt
@@ -1,0 +1,2 @@
+# Development dependencies for the Token Metrics AI API Python SDK
+-e .[dev]

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -17,8 +17,14 @@ classifiers =
 [options]
 packages = find:
 install_requires =
-    requests
-    pandas
-    matplotlib
-    vectorbt
-    tqdm
+    requests>=2.28
+
+[options.extras_require]
+dataframe =
+    pandas>=1.3
+analysis =
+    matplotlib>=3.5
+    vectorbt>=0.25
+dev =
+    pytest>=7.0
+    requests-mock>=1.11

--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -1,15 +1,24 @@
+import os
 import unittest
 from unittest import mock
+
+import requests
+
 from tmai_api import TokenMetricsClient
+from tmai_api.exceptions import MissingAPIKeyError
 
 class TestTokenMetricsClient(unittest.TestCase):
     
     def setUp(self):
-        self.client = TokenMetricsClient(api_key="test-api-key")
+        self.session = mock.Mock(spec=requests.Session)
+        # Ensure the mock session exposes a request method for the HTTP layer
+        self.session.request = mock.Mock()
+        self.client = TokenMetricsClient(api_key="test-api-key", session=self.session)
     
     def test_client_initialization(self):
         self.assertEqual(self.client.api_key, "test-api-key")
         self.assertEqual(self.client.BASE_URL, "https://api.tokenmetrics.com/v2")
+        self.assertEqual(self.client.base_url, "https://api.tokenmetrics.com/v2")
         
         # Check that all endpoints are initialized
         self.assertIsNotNone(self.client.tokens)
@@ -24,31 +33,25 @@ class TestTokenMetricsClient(unittest.TestCase):
         self.assertIsNotNone(self.client.ai_reports)
         self.assertIsNotNone(self.client.trading_signals)
 
-    @mock.patch('requests.get')
-    def test_tokens_endpoint(self, mock_get):
-        # Setup mock response
+    def test_tokens_endpoint(self):
         mock_response = mock.Mock()
         mock_response.json.return_value = {"data": [{"symbol": "BTC", "name": "Bitcoin"}]}
         mock_response.raise_for_status.return_value = None
-        mock_get.return_value = mock_response
-        
-        # Call the endpoint
+        self.session.request.return_value = mock_response
+
         result = self.client.tokens.get(symbol="BTC")
-        
-        # Verify the result
+
         self.assertEqual(result, {"data": [{"symbol": "BTC", "name": "Bitcoin"}]})
-        
-        # Verify the request was made correctly
-        mock_get.assert_called_once()
-        args, kwargs = mock_get.call_args
+
+        self.session.request.assert_called_once()
+        _, kwargs = self.session.request.call_args
         self.assertEqual(kwargs['params'], {'symbol': 'BTC'})
         self.assertEqual(kwargs['headers']['api_key'], 'test-api-key')
+        self.assertEqual(kwargs['method'], 'GET')
 
-    @mock.patch('requests.post')
-    def test_ai_agent_endpoint(self, mock_post):
-        # Setup mock response
+    def test_ai_agent_endpoint(self):
         mock_response = mock.Mock()
-        mock_response.json.return_value = {
+        payload = {
             "success": True,
             "message": "AI Chatbot response successful",
             "answer": "This is a test answer from the AI chatbot.",
@@ -57,76 +60,77 @@ class TestTokenMetricsClient(unittest.TestCase):
                 {"chatbot": "This is a test answer from the AI chatbot."}
             ]
         }
+        mock_response.json.return_value = payload
         mock_response.raise_for_status.return_value = None
-        mock_post.return_value = mock_response
-        
-        # Call the endpoint
+        self.session.request.return_value = mock_response
+
         question = "What is the next 100x coin?"
         result = self.client.ai_agent.ask(question)
-        
-        # Verify the result
+
         self.assertTrue(result.get("success"))
         self.assertEqual(result.get("answer"), "This is a test answer from the AI chatbot.")
-        
-        # Verify the request was made correctly
-        mock_post.assert_called_once()
-        args, kwargs = mock_post.call_args
+
+        self.assertGreaterEqual(self.session.request.call_count, 1)
+        _, kwargs = self.session.request.call_args_list[0]
         self.assertEqual(kwargs['json'], {'messages': [{'user': question}]})
         self.assertEqual(kwargs['headers']['api_key'], 'test-api-key')
-        
-        # Test get_answer_text method
+        self.assertEqual(kwargs['method'], 'POST')
+
         answer_text = self.client.ai_agent.get_answer_text(question)
         self.assertEqual(answer_text, "This is a test answer from the AI chatbot.")
+        self.assertEqual(self.session.request.call_count, 2)
 
-    @mock.patch('requests.get')
-    def test_ai_reports_endpoint(self, mock_get):
-        # Setup mock response
+    def test_ai_reports_endpoint(self):
         mock_response = mock.Mock()
         mock_response.json.return_value = {"data": [{"report_id": "123", "token": "BTC"}]}
         mock_response.raise_for_status.return_value = None
-        mock_get.return_value = mock_response
-        
-        # Call the endpoint
+        self.session.request.return_value = mock_response
+
         result = self.client.ai_reports.get(symbol="BTC")
-        
-        # Verify the result
+
         self.assertEqual(result, {"data": [{"report_id": "123", "token": "BTC"}]})
-        
-        # Verify the request was made correctly
-        mock_get.assert_called_once()
-        args, kwargs = mock_get.call_args
+
+        self.session.request.assert_called()
+        _, kwargs = self.session.request.call_args
         self.assertEqual(kwargs['params'], {'symbol': 'BTC'})
         self.assertEqual(kwargs['headers']['api_key'], 'test-api-key')
+        self.assertEqual(kwargs['method'], 'GET')
 
-    @mock.patch('requests.get')
-    def test_trading_signals_endpoint(self, mock_get):
-        # Setup mock response
+    def test_trading_signals_endpoint(self):
         mock_response = mock.Mock()
         mock_response.json.return_value = {"data": [{"signal": "1", "token": "BTC"}]}
         mock_response.raise_for_status.return_value = None
-        mock_get.return_value = mock_response
-        
-        # Call the endpoint
+        self.session.request.return_value = mock_response
+
         result = self.client.trading_signals.get(
-            symbol="BTC", 
-            startDate="2023-10-01", 
+            symbol="BTC",
+            startDate="2023-10-01",
             endDate="2023-10-10",
             signal="1"
         )
-        
-        # Verify the result
+
         self.assertEqual(result, {"data": [{"signal": "1", "token": "BTC"}]})
-        
-        # Verify the request was made correctly
-        mock_get.assert_called_once()
-        args, kwargs = mock_get.call_args
+
+        self.session.request.assert_called()
+        _, kwargs = self.session.request.call_args
         self.assertEqual(kwargs['params'], {
-            'symbol': 'BTC', 
-            'startDate': '2023-10-01', 
+            'symbol': 'BTC',
+            'startDate': '2023-10-01',
             'endDate': '2023-10-10',
             'signal': '1'
         })
         self.assertEqual(kwargs['headers']['api_key'], 'test-api-key')
+        self.assertEqual(kwargs['method'], 'GET')
+
+    def test_api_key_from_environment(self):
+        with mock.patch.dict(os.environ, {"TMAI_API_KEY": "env-api-key"}):
+            client = TokenMetricsClient(session=self.session)
+            self.assertEqual(client.api_key, "env-api-key")
+
+    def test_missing_api_key_raises(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            with self.assertRaises(MissingAPIKeyError):
+                TokenMetricsClient(session=self.session)
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/tmai_api/__init__.py
+++ b/python/tmai_api/__init__.py
@@ -1,4 +1,5 @@
 from tmai_api.client import TokenMetricsClient
+from tmai_api.exceptions import APIRequestError, MissingAPIKeyError
 
-__all__ = ["TokenMetricsClient"]
+__all__ = ["TokenMetricsClient", "APIRequestError", "MissingAPIKeyError"]
 __version__ = "0.3.0"

--- a/python/tmai_api/base.py
+++ b/python/tmai_api/base.py
@@ -1,7 +1,16 @@
-import requests
-import pandas as pd
 import datetime
-from tqdm import tqdm
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
+
+import requests
+
+from .exceptions import APIRequestError
+
+# Optional pandas support. Import lazily so the core SDK can be used without the
+# heavy dependency unless dataframe conversion is explicitly requested.
+try:  # pragma: no cover - exercised indirectly when pandas is installed
+    import pandas as pd  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - import side effect only
+    pd = None
 
 class BaseEndpoint:
     """Base class for all API endpoints"""
@@ -13,7 +22,7 @@ class BaseEndpoint:
             client: TokenMetricsClient instance
         """
         self.client = client
-        self.base_url = client.BASE_URL
+        self.base_url = client.base_url
     
     def _request(self, method, endpoint, params=None, json=None):
         """Make a request to the API.
@@ -27,23 +36,34 @@ class BaseEndpoint:
         Returns:
             dict: API response data
         """
-        url = f"{self.base_url}/{endpoint}"
-        headers = {
-            "accept": "application/json",
-            "api_key": self.client.api_key
-        }
-        
-        if method.lower() == "get":
-            response = requests.get(url, headers=headers, params=params)
-        elif method.lower() == "post":
-            headers["content-type"] = "application/json"
-            response = requests.post(url, headers=headers, json=json)
-        else:
+        url = f"{self.base_url}/{endpoint}".rstrip("/")
+        method = method.upper()
+
+        if method not in {"GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD"}:
             raise ValueError(f"Unsupported HTTP method: {method}")
-        
-        # Raise an exception if the request failed
-        response.raise_for_status()
-        
+
+        headers = self.client.build_headers()
+        if method in {"POST", "PUT", "PATCH"}:
+            headers.setdefault("content-type", "application/json")
+
+        try:
+            response = self.client.session.request(
+                method=method,
+                url=url,
+                headers=headers,
+                params=params,
+                json=json,
+                timeout=self.client.timeout,
+            )
+            response.raise_for_status()
+        except requests.RequestException as exc:  # pragma: no cover - requests raises detailed exceptions
+            raise APIRequestError(
+                endpoint=endpoint,
+                method=method,
+                params=params,
+                status_code=getattr(exc.response, "status_code", None),
+            ) from exc
+
         return response.json()
     
     def _chunk_date_range(self, startDate, endDate, max_days=29):
@@ -90,7 +110,14 @@ class BaseEndpoint:
             
         return result
     
-    def _paginated_request(self, method, endpoint, params=None, max_days=29, custom_limit=None):
+    def _paginated_request(
+        self,
+        method: str,
+        endpoint: str,
+        params: Optional[Dict[str, Any]] = None,
+        max_days: int = 29,
+        custom_limit: Optional[int] = None,
+    ) -> Union[Dict[str, Any], List[Any]]:
         """Make paginated requests to handle date ranges and custom pagination logic.
         
         This method handles two forms of pagination:
@@ -119,8 +146,7 @@ class BaseEndpoint:
             # Default for any other endpoint
             'default': 1000
         }
-        if params is None:
-            params = {}
+        params = dict(params or {})
             
         # Extract date parameters
         startDate = params.get('startDate')
@@ -136,90 +162,161 @@ class BaseEndpoint:
         # Override user-provided limit with our internal limit
         params['limit'] = limit
         
-        # We'll remove page parameter since we're handling pagination ourselves
         if 'page' in params:
             del params['page']
-            
-        # If no date range or already within limits, we still need to handle pagination
+
         if not startDate or not endDate:
-            date_chunks = [(startDate, endDate)]
+            date_chunks: Iterable[Tuple[Optional[str], Optional[str]]] = [(startDate, endDate)]
         else:
-            # Split date range into chunks
             date_chunks = self._chunk_date_range(startDate, endDate, max_days)
-        
-        # Initialize combined results
-        all_data = []
-        combined_meta = {}
-        
-        # Calculate total iterations for progress bar
-        total_iterations = len(date_chunks)
-        
-        # Setup progress bar
-        with tqdm(total=total_iterations, desc=f"Fetching {endpoint} data", unit="chunk") as pbar:
-            # Process each date chunk
-            for chunk_start, chunk_end in date_chunks:
-                # Update date parameters
-                chunk_params = params.copy()
-                if chunk_start:
-                    chunk_params['startDate'] = chunk_start
-                if chunk_end:
-                    chunk_params['endDate'] = chunk_end
-                
-                # Set a high limit to get as much data as possible in one request
-                chunk_params['limit'] = limit
-                
-                # Always start with page 0 for each chunk
-                chunk_params['page'] = 0
-                
-                # Try to get data for this date chunk, but handle errors gracefully
+
+        all_data: List[Any] = []
+        combined_meta: Dict[str, Any] = {}
+        errors: List[Dict[str, Any]] = []
+
+        progress_callback: Optional[Callable[[Dict[str, Any]], None]] = getattr(
+            self.client, "progress_callback", None
+        )
+
+        for chunk_start, chunk_end in date_chunks:
+            chunk_params = params.copy()
+            if chunk_start:
+                chunk_params['startDate'] = chunk_start
+            if chunk_end:
+                chunk_params['endDate'] = chunk_end
+            chunk_params['limit'] = limit
+
+            next_page: Optional[int] = params.get('page', 0) or 0
+
+            while True:
+                chunk_params['page'] = next_page
+
                 try:
                     response = self._request(method, endpoint, chunk_params)
-                    
-                    # Extract and store the data
-                    if isinstance(response, dict):
-                        if "data" in response:
-                            data_items = response["data"]
-                            if isinstance(data_items, list):
-                                all_data.extend(data_items)
-                            else:
-                                all_data.append(data_items)
-                        
-                        # Store metadata for later if it exists
-                        for key, value in response.items():
-                            if key != "data":
-                                combined_meta[key] = value
-                    else:
-                        # If the response is not a dict with a data field, append it directly
-                        if isinstance(response, list):
-                            all_data.extend(response)
-                        else:
-                            all_data.append(response)
-                except Exception as e:
-                    # Silently skip this chunk and continue with the next one
-                    # No need to print warnings as they would clutter the user's output
-                    pass
-                
-                # Update progress bar
-                pbar.update(1)
-        
-        # Check if we got any data at all
-        if not all_data:
-            # Silently return an empty dataset with consistent structure
-            # No need to print warnings as they would clutter the user's output
-            return {"data": []}
-            
-        # Construct the final response
+                except APIRequestError as exc:
+                    if self.client.allow_partial_results:
+                        errors.append({
+                            "chunk": {
+                                "startDate": chunk_start,
+                                "endDate": chunk_end,
+                                "page": next_page,
+                            },
+                            "error": str(exc),
+                        })
+                        break
+                    raise
+
+                data_items, metadata = self._extract_data(response)
+
+                if data_items:
+                    all_data.extend(data_items)
+
+                combined_meta.update(metadata)
+
+                if progress_callback:
+                    progress_callback({
+                        "endpoint": endpoint,
+                        "chunk": {
+                            "startDate": chunk_start,
+                            "endDate": chunk_end,
+                        },
+                        "page": next_page,
+                        "items_fetched": len(data_items),
+                    })
+
+                next_page = self._calculate_next_page(
+                    metadata=metadata,
+                    previous_page=next_page,
+                    received=len(data_items),
+                    page_size=limit,
+                )
+
+                if next_page is None:
+                    break
+
+        result: Union[List[Any], Dict[str, Any]]
         if combined_meta:
-            result = combined_meta.copy()
-            result["data"] = all_data
-            return result
+            result = dict(combined_meta)
+            result['data'] = all_data
         elif all_data and isinstance(all_data[0], dict):
-            # If we have data items and they're dictionaries, return in standard format
-            return {"data": all_data}
+            result = {"data": all_data}
         else:
-            # Otherwise, return just the data array
-            return all_data
-    
+            result = all_data
+
+        if errors:
+            if isinstance(result, dict):
+                result = dict(result)
+                result['errors'] = errors
+                return result
+            return {"data": result, "errors": errors}
+
+        if isinstance(result, list):
+            return result
+
+        return result
+
+    def _extract_data(self, response: Any) -> Tuple[List[Any], Dict[str, Any]]:
+        """Normalize API responses into data payload and metadata."""
+        if isinstance(response, dict):
+            metadata = {key: value for key, value in response.items() if key != "data"}
+            data_payload = response.get("data")
+            if isinstance(data_payload, list):
+                return data_payload, metadata
+            if data_payload is None:
+                return [], metadata
+            return [data_payload], metadata
+
+        if isinstance(response, list):
+            return response, {}
+
+        return [response], {}
+
+    def _calculate_next_page(
+        self,
+        metadata: Dict[str, Any],
+        previous_page: Optional[Any],
+        received: int,
+        page_size: int,
+    ) -> Optional[Any]:
+        """Determine the next page identifier based on metadata and payload size."""
+
+        try:
+            previous_numeric = int(previous_page) if previous_page is not None else None
+        except (TypeError, ValueError):
+            previous_numeric = None
+
+        for key in ("next_page", "nextPage", "next_page_token", "nextPageToken"):
+            if key in metadata and metadata[key] not in (None, ""):
+                try:
+                    return int(metadata[key])
+                except (TypeError, ValueError):
+                    return metadata[key]
+
+        total_pages = metadata.get("total_pages") or metadata.get("totalPages")
+        current_page = metadata.get("page") or metadata.get("current_page") or metadata.get("currentPage")
+        if total_pages is not None and current_page is not None:
+            try:
+                if int(current_page) + 1 < int(total_pages):
+                    return int(current_page) + 1
+                return None
+            except (TypeError, ValueError):
+                return None
+
+        has_more = metadata.get("has_more") or metadata.get("hasMore")
+        if has_more is False:
+            return None
+        if has_more is True:
+            base = previous_numeric if previous_numeric is not None else 0
+            return base + 1
+
+        if received < page_size or page_size == 0:
+            return None
+
+        if previous_numeric is None:
+            return None
+
+        return previous_numeric + 1
+
     def to_dataframe(self, data):
         """Convert API response data to a pandas DataFrame.
         
@@ -231,6 +328,13 @@ class BaseEndpoint:
         """
         # Implementation depends on the specific structure of each endpoint's response
         # This is a placeholder to be overridden by subclasses
+        if pd is None:
+            raise ImportError(
+                "pandas is required for DataFrame conversion. Install the optional "
+                "dependency with `pip install tmai-api[dataframe]` or add pandas "
+                "to your project."
+            )
+
         if isinstance(data, list):
             if not data:  # Handle empty list
                 return pd.DataFrame()

--- a/python/tmai_api/client.py
+++ b/python/tmai_api/client.py
@@ -1,3 +1,9 @@
+import os
+from typing import Callable, Optional, Tuple
+
+import requests
+from urllib3.util import Retry
+
 from tmai_api.endpoints.tokens import TokensEndpoint
 from tmai_api.endpoints.hourly_ohlcv import HourlyOHLCVEndpoint
 from tmai_api.endpoints.daily_ohlcv import DailyOHLCVEndpoint
@@ -8,19 +14,48 @@ from tmai_api.endpoints.market_metrics import MarketMetricsEndpoint
 from tmai_api.endpoints.ai_agent import AIAgentEndpoint
 from tmai_api.endpoints.ai_reports import AIReportsEndpoint
 from tmai_api.endpoints.trading_signals import TradingSignalsEndpoint
+from tmai_api.exceptions import MissingAPIKeyError
 
 class TokenMetricsClient:
     """Main client for interacting with the Token Metrics AI API."""
     
     BASE_URL = "https://api.tokenmetrics.com/v2"
     
-    def __init__(self, api_key=None):
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        *,
+        base_url: Optional[str] = None,
+        timeout: float = 10.0,
+        max_retries: int = 3,
+        backoff_factor: float = 0.5,
+        status_forcelist: Optional[Tuple[int, ...]] = None,
+        session: Optional[requests.Session] = None,
+        allow_partial_results: bool = False,
+        progress_callback: Optional[Callable[[dict], None]] = None,
+    ):
         """Initialize the Token Metrics client.
         
         Args:
             api_key (str): Your Token Metrics API key
         """
-        self.api_key = api_key
+        self.api_key = api_key or os.getenv("TMAI_API_KEY")
+        if not self.api_key:
+            raise MissingAPIKeyError(
+                "An API key is required. Provide it explicitly or set the TMAI_API_KEY environment variable."
+            )
+
+        self.base_url = (base_url or self.BASE_URL).rstrip("/")
+        self.timeout = timeout
+        self.allow_partial_results = allow_partial_results
+        self.progress_callback = progress_callback
+
+        self._session = session or self._build_session(
+            max_retries=max_retries,
+            backoff_factor=backoff_factor,
+            status_forcelist=status_forcelist,
+        )
+
         self.tokens = TokensEndpoint(self)
         self.hourly_ohlcv = HourlyOHLCVEndpoint(self)
         self.daily_ohlcv = DailyOHLCVEndpoint(self)
@@ -31,3 +66,34 @@ class TokenMetricsClient:
         self.ai_agent = AIAgentEndpoint(self)
         self.ai_reports = AIReportsEndpoint(self)
         self.trading_signals = TradingSignalsEndpoint(self)
+
+    @property
+    def session(self) -> requests.Session:
+        return self._session
+
+    def _build_session(
+        self,
+        *,
+        max_retries: int,
+        backoff_factor: float,
+        status_forcelist: Optional[Tuple[int, ...]],
+    ) -> requests.Session:
+        session = requests.Session()
+        retry = Retry(
+            total=max_retries,
+            read=max_retries,
+            connect=max_retries,
+            backoff_factor=backoff_factor,
+            status_forcelist=status_forcelist or (429, 500, 502, 503, 504),
+            allowed_methods=("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "HEAD"),
+        )
+        adapter = requests.adapters.HTTPAdapter(max_retries=retry)
+        session.mount("http://", adapter)
+        session.mount("https://", adapter)
+        return session
+
+    def build_headers(self) -> dict:
+        return {
+            "accept": "application/json",
+            "api_key": self.api_key,
+        }

--- a/python/tmai_api/exceptions.py
+++ b/python/tmai_api/exceptions.py
@@ -1,0 +1,34 @@
+"""Custom exceptions used throughout the Token Metrics SDK."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+
+class MissingAPIKeyError(ValueError):
+    """Raised when the API key is missing from configuration."""
+
+
+class APIRequestError(Exception):
+    """Represents an error returned by the Token Metrics API."""
+
+    def __init__(
+        self,
+        *,
+        endpoint: str,
+        method: str,
+        params: Optional[Dict[str, Any]] = None,
+        status_code: Optional[int] = None,
+    ) -> None:
+        self.endpoint = endpoint
+        self.method = method
+        self.params = params or {}
+        self.status_code = status_code
+        super().__init__(self.__str__())
+
+    def __str__(self) -> str:
+        status = f" status={self.status_code}" if self.status_code is not None else ""
+        return (
+            f"API request failed:{status} method={self.method} endpoint={self.endpoint} "
+            f"params={self.params}"
+        )


### PR DESCRIPTION
## Summary
- add a resilient HTTP session with retries/timeouts, structured errors, and smarter pagination to the Python SDK while making pandas optional
- require API keys via environment variables, document development setup, and add lightweight dev dependency metadata with a requirements file and gitignore updates
- harden the JavaScript SDK by introducing a configurable axios client with retries, removing the hard-coded API key, exposing custom errors, and trimming runtime dependencies

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68f07ab35ad4832e9fba207d60e0cbb0